### PR TITLE
Schema validation has been turned on in Istio 1.6, so that sni_hosts …

### DIFF
--- a/helm-charts/grpc-demo-services-istio/templates/httpbin-virtualservice.yaml
+++ b/helm-charts/grpc-demo-services-istio/templates/httpbin-virtualservice.yaml
@@ -19,7 +19,7 @@ spec:
     - gateways:
       - mesh
       port: 443
-      sni_hosts:
+      sniHosts:
       - httpbin.org
     route:
     - destination:
@@ -30,7 +30,7 @@ spec:
     - gateways:
       - httpbin
       port: 443
-      sni_hosts:
+      sniHosts:
       - httpbin.org
     route:
     - destination:

--- a/openshift-templates/grpc-demo-template-istio.yaml
+++ b/openshift-templates/grpc-demo-template-istio.yaml
@@ -632,7 +632,7 @@ objects:
       - gateways:
         - mesh
         port: 443
-        sni_hosts:
+        sniHosts:
         - httpbin.org
       route:
       - destination:
@@ -643,7 +643,7 @@ objects:
       - gateways:
         - httpbin
         port: 443
-        sni_hosts:
+        sniHosts:
         - httpbin.org
       route:
       - destination:


### PR DESCRIPTION
…is not longer accepted. The new parameter is sniHosts. More information on this issue: https://github.com/istio/istio/issues/25103

Note: This change should not break compatibility with OSSM 1.x.